### PR TITLE
Add fewest and most tackles

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -158,6 +158,16 @@ class StatTracker
     team_wins_as_home(team_id, season) + team_wins_as_away(team_id, season)
   end
 
+  def game_ids_by_season(season)
+    filter_by_season(season).map do |game|
+      game.game_id
+    end.sort 
+  end
+
+  def team_tackles(season)
+    require "pry"; binding.pry
+  end
+
 # ~~~ Game Methods ~~~
   def lowest_total_score(season)
     sum_game_goals(season).min_by do |game_id, score|

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -179,6 +179,12 @@ class StatTracker
     team_season_tackles
   end
 
+  def team_identifier(team_id)
+    @teams.find do |team|
+      team.team_id == team_id
+    end.team_name 
+  end
+
 # ~~~ Game Methods ~~~
   def lowest_total_score(season)
     sum_game_goals(season).min_by do |game_id, score|
@@ -250,6 +256,11 @@ class StatTracker
     @game_teams.find do |game_team|
       game_team.team_id == worst_team(season)
     end.head_coach
+  end
+
+  def most_tackles(season)
+    team_tackles(season).max_by do |team|
+    end
   end
 
 # ~~~ TEAM METHODS~~~

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -175,7 +175,7 @@ class StatTracker
       else
         team_season_tackles[game.team_id] = game.tackles
       end
-    end 
+    end
     team_season_tackles
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -161,11 +161,22 @@ class StatTracker
   def game_ids_by_season(season)
     filter_by_season(season).map do |game|
       game.game_id
-    end.sort 
+    end.sort
   end
 
   def team_tackles(season)
-    require "pry"; binding.pry
+    team_season_tackles = {}
+    games = @game_teams.find_all do |game|
+      game_ids_by_season(season).include?(game.game_id)
+    end
+    games.each do |game|
+      if team_season_tackles[game.team_id]
+        team_season_tackles[game.team_id] += game.tackles
+      else
+        team_season_tackles[game.team_id] = game.tackles
+      end
+    end 
+    team_season_tackles
   end
 
 # ~~~ Game Methods ~~~

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -264,7 +264,11 @@ class StatTracker
     end.first)
   end
 
-  
+  def fewest_tackles(season)
+    team_identifier(team_tackles(season).min_by do |team|
+      team.last
+    end.first)
+  end
 
 # ~~~ TEAM METHODS~~~
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -182,7 +182,7 @@ class StatTracker
   def team_identifier(team_id)
     @teams.find do |team|
       team.team_id == team_id
-    end.team_name 
+    end.team_name
   end
 
 # ~~~ Game Methods ~~~
@@ -259,9 +259,12 @@ class StatTracker
   end
 
   def most_tackles(season)
-    team_tackles(season).max_by do |team|
-    end
+    team_identifier(team_tackles(season).max_by do |team|
+      team.last
+    end.first)
   end
+
+  
 
 # ~~~ TEAM METHODS~~~
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -181,7 +181,7 @@ class StatTrackerTest < Minitest::Test
     assert_equal expected, @stats.game_ids_by_season("20122013")
   end
 
-  def test_it_can_show_total_tackles_per_team_per_season
+  def test_it_can_show_total_tackles_per_team_per_season ###
     expected = {
       1 => 30,
       4 => 108,
@@ -255,6 +255,10 @@ end
 
 def test_it_can_determine_team_with_most_season_tackles
   assert_equal "Chicago Fire", @stats.most_tackles("20122013")
+end
+
+def test_it_can_determine_team_with_fewest_season_tackles
+  assert_equal "DC United", @stats.fewest_tackles("20122013")
 end
 
 # ~~~ TEAM METHOD TESTS~~~

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -176,7 +176,13 @@ class StatTrackerTest < Minitest::Test
     assert_equal expected, @stats.ratio(2,3)
   end
 
+  def test_it_can_return_array_of_game_ids_per_season
+    expected = [2012020030, 2012020133, 2012020355, 2012020389]
+    assert_equal expected, @stats.game_ids_by_season("20122013")
+  end
+
   def test_it_can_show_total_tackles_per_team_per_season
+    skip
     expected = {
       1 => 30,
       4 => 108,

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -245,5 +245,9 @@ def test_it_can_determine_the_worst_coach_by_season
   assert_equal "Jon Cooper", @stats.worst_coach("20142015")
 end
 
+def test_it_can_determine_team_with_most_season_tackles
+  assert_equal "Chicago Fire", @stats.most_tackles 
+end
+
 # ~~~ TEAM METHOD TESTS~~~
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -192,6 +192,14 @@ class StatTrackerTest < Minitest::Test
     assert_equal expected, @stats.team_tackles("20122013")
   end
 
+  def test_team_identifier_can_return_team_string
+    assert_equal "Atlanta United", @stats.team_identifier(1)
+    assert_equal "Chicago Fire", @stats.team_identifier(4)
+    assert_equal "FC Cincinnati", @stats.team_identifier(26)
+    assert_equal "DC United", @stats.team_identifier(14)
+    assert_equal "FC Dallas", @stats.team_identifier(6)
+  end
+
 # ~~~ GAME METHOD TESTS~~~
   def test_it_can_get_percentage_away_games_won ###
     assert_equal 30.19, @stats.percentage_away_wins
@@ -246,7 +254,7 @@ def test_it_can_determine_the_worst_coach_by_season
 end
 
 def test_it_can_determine_team_with_most_season_tackles
-  assert_equal "Chicago Fire", @stats.most_tackles 
+  assert_equal "Chicago Fire", @stats.most_tackles("20122013")
 end
 
 # ~~~ TEAM METHOD TESTS~~~

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -135,7 +135,7 @@ class StatTrackerTest < Minitest::Test
   def test_it_can_determine_team_with_worst_winning_percentage
     assert_equal 14, @stats.worst_team("20142015")
   end
-  
+
   def test_it_can_get_team_name_from_team_id
     assert_equal "Chicago Fire", @stats.team_names_by_team_id(4)
   end
@@ -171,10 +171,20 @@ class StatTrackerTest < Minitest::Test
     assert_equal 67, @stats.total_goals(season_1415)
   end
 
-
   def test_it_can_calc_a_ratio
     expected = 0.67
     assert_equal expected, @stats.ratio(2,3)
+  end
+
+  def test_it_can_show_total_tackles_per_team_per_season
+    expected = {
+      1 => 30,
+      4 => 108,
+      6 => 31,
+      14 => 17,
+      26 => 0
+    }
+    assert_equal expected, @stats.team_tackles("20122013")
   end
 
 # ~~~ GAME METHOD TESTS~~~
@@ -203,8 +213,6 @@ class StatTrackerTest < Minitest::Test
   def test_it_can_get_avg_goals_per_game
     assert_equal 3.98, @stats.avg_goals_per_game
   end
-
-
 
   def test_it_can_determine_highest_and_lowest_game_score
     assert_equal 2, @stats.lowest_total_score("20142015")

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -182,13 +182,12 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_it_can_show_total_tackles_per_team_per_season
-    skip
     expected = {
       1 => 30,
       4 => 108,
       6 => 31,
-      14 => 17,
-      26 => 0
+      14 => 17
+      # 26 => 0
     }
     assert_equal expected, @stats.team_tackles("20122013")
   end


### PR DESCRIPTION
This PR: 
- Writes #most_tackles and #fewest_tackles season methods with passing tests
- Writes several helper methods with tests including: 

#game_ids_by_season (returns an array of all game_ids for a season), 

#team_tackles (returns hash with team_id key and total season tackles value), 

#team_identifier (returns team string name given team_id as an argument).