### PR TITLE
Season accurate team methods

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -217,7 +217,6 @@ class StatTracker
     count
   end
 
-
 # ~~~ LEAGUE METHODS~~~
   def worst_offense
     worst = average_scores_by_team.min_by {|id, average| average}

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -234,6 +234,8 @@ class StatTracker
   end
 
   def most_accurate_team(season)
+    most_accurate = shots_per_goal_per_season(season).min_by { |team, avg| avg}
+    team_names_by_team_id(most_accurate[0])
   end
 
   def least_accurate_team(season)

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -226,8 +226,8 @@ class StatTracker
   end
 
   def shots_per_goal_per_season(season)
-    season_goals.merge(team_shots_from_game_ids(game_ids_per_season(season))) do |team_id, goals, shots|
-      (goals / shots.to_f).round(3)
+    season_goals(season).merge(shots_per_team_id(season)) do |team_id, goals, shots|
+      (shots.to_f / goals).round(2)
     end
 
     # NAME OF TEAM with best ratio of shots-to-goals for SPECIFIC SEASON
@@ -236,7 +236,7 @@ class StatTracker
   def most_accurate_team(season)
   end
 
-  def least_accurate_team
+  def least_accurate_team(season)
     # NAME OF TEAM with worst ratio of shots-to-goals for SPECIFIC SEASON
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,7 +1,7 @@
 require "csv"
-require "./lib/team"
-require "./lib/game"
-require "./lib/game_team"
+require_relative "./team"
+require_relative "./game"
+require_relative "./game_team"
 
 class StatTracker
   attr_reader :teams, :games, :game_teams
@@ -71,7 +71,7 @@ class StatTracker
     end
     team_id_hash[id.to_s]
   end
-  
+
   def filter_by_season(season)
     @games.find_all do |game|
       game.season == season
@@ -193,6 +193,52 @@ class StatTracker
   end
 
 # ~~~ SEASON METHODS~~~
+  def game_ids_per_season(season)
+    specific_season = season_group[season]
+    specific_season.map do |games|
+      games.game_id
+    end
+  end
+
+  def find_game_teams(game_ids)
+    game_ids.flat_map do |game_id|
+      @game_teams.find_all do |game|
+        game_id == game.game_id
+      end
+    end
+  end
+
+  def shots_per_team_id(season)
+    game_search = find_game_teams(game_ids_per_season(season))
+    game_search.reduce(Hash.new(0)) do |results, game|
+      results[game.team_id.to_s] += game.shots
+      results
+    end
+  end
+
+  def season_goals(season)
+    specific_season = season_group[season]
+    specific_season.reduce(Hash.new(0)) do |season_goals, game|
+      season_goals[game.away_team_id.to_s] += game.away_goals
+      season_goals[game.home_team_id.to_s] += game.home_goals
+      season_goals
+    end
+  end
+
+  def shots_per_goal_per_season(season)
+    season_goals.merge(team_shots_from_game_ids(game_ids_per_season(season))) do |team_id, goals, shots|
+      (goals / shots.to_f).round(3)
+    end
+
+    # NAME OF TEAM with best ratio of shots-to-goals for SPECIFIC SEASON
+  end
+
+  def most_accurate_team(season)
+  end
+
+  def least_accurate_team
+    # NAME OF TEAM with worst ratio of shots-to-goals for SPECIFIC SEASON
+  end
 
 # ~~~ TEAM METHODS~~~
 

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -189,7 +189,6 @@ class StatTrackerTest < Minitest::Test
     assert_equal "FC Dallas", @stats.best_offense
   end
 
-
 # ~~~ SEASON METHOD TESTS~~~
 
 def test_it_can_get_most_accurate_team_for_season

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -186,6 +186,11 @@ def test_it_can_find_goals_per_season
   assert_equal expected, @stats.season_goals("20132014")
 end
 
+def test_shots_per_goal_per_season_for_given_season
+  expected = {"4"=>3.20, "14"=>2.89, "1"=>3.86, "6"=>2.40, "26"=>3.64}
+  assert_equal expected, @stats.shots_per_goal_per_season("20132014")
+end
+
 
 # ~~~ TEAM METHOD TESTS~~~
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -131,6 +131,32 @@ class StatTrackerTest < Minitest::Test
     assert_equal expected, @stats.average_scores_by_team
   end
 
+  def test_it_can_get_game_ids_in_season
+    expected = [2013021198, 2013020371, 2013020203, 2013020649, 2013021160, 2013020334, 2013021221, 2013020667, 2013020321, 2013020285, 2013020739, 2013020088]
+    assert_equal expected, @stats.game_ids_per_season("20132014")
+  end
+
+  def test_it_can_get_games_from_season_game_ids
+    season_game_ids = @stats.game_ids_per_season("20132014")
+    assert_equal GameTeam, @stats.find_game_teams(season_game_ids)[0].class
+    assert_equal (season_game_ids.count * 2), @stats.find_game_teams(season_game_ids).count
+  end
+
+  def test_it_can_get_shots_per_team
+    expected = {"4"=>32, "14"=>26, "1"=>27, "6"=>24, "26"=>40}
+    assert_equal expected, @stats.shots_per_team_id("20132014")
+  end
+
+  def test_it_can_find_goals_per_season
+    expected = {"4"=>10, "14"=>9, "1"=>7, "6"=>10, "26"=>11}
+    assert_equal expected, @stats.season_goals("20132014")
+  end
+
+  def test_shots_per_goal_per_season_for_given_season
+    expected = {"4"=>3.20, "14"=>2.89, "1"=>3.86, "6"=>2.40, "26"=>3.64}
+    assert_equal expected, @stats.shots_per_goal_per_season("20132014")
+  end
+
 # ~~~ GAME METHOD TESTS~~~
   def test_it_can_get_percentage_away_games_won ###
     assert_equal 30.19, @stats.percentage_away_wins
@@ -154,22 +180,6 @@ class StatTrackerTest < Minitest::Test
     assert_equal 6, @stats.highest_total_score("20142015")
   end
 
-  def test_it_can_get_game_ids_in_season
-    expected = [2013021198, 2013020371, 2013020203, 2013020649, 2013021160, 2013020334, 2013021221, 2013020667, 2013020321, 2013020285, 2013020739, 2013020088]
-    assert_equal expected, @stats.game_ids_per_season("20132014")
-  end
-
-  def test_it_can_get_games_from_season_game_ids
-    season_game_ids = @stats.game_ids_per_season("20132014")
-    assert_equal GameTeam, @stats.find_game_teams(season_game_ids)[0].class
-    assert_equal (season_game_ids.count * 2), @stats.find_game_teams(season_game_ids).count
-  end
-
-  def test_it_can_get_shots_per_team
-    expected = {"4"=>32, "14"=>26, "1"=>27, "6"=>24, "26"=>40}
-    assert_equal expected, @stats.shots_per_team_id("20132014")
-  end
-
 # ~~~ LEAGUE METHOD TESTS~~~
   def test_worst_offense
     assert_equal "Chicago Fire", @stats.worst_offense
@@ -181,20 +191,14 @@ class StatTrackerTest < Minitest::Test
 
 
 # ~~~ SEASON METHOD TESTS~~~
-def test_it_can_find_goals_per_season
-  expected = {"4"=>10, "14"=>9, "1"=>7, "6"=>10, "26"=>11}
-  assert_equal expected, @stats.season_goals("20132014")
-end
 
-def test_shots_per_goal_per_season_for_given_season
-  expected = {"4"=>3.20, "14"=>2.89, "1"=>3.86, "6"=>2.40, "26"=>3.64}
-  assert_equal expected, @stats.shots_per_goal_per_season("20132014")
-end
-
-def test_it_can_get_most_accurate_team
+def test_it_can_get_most_accurate_team_for_season
   assert_equal "FC Dallas", @stats.most_accurate_team("20132014")
 end
 
+def test_it_can_get_least_accurate_team_for_season
+  assert_equal "Atlanta United", @stats.least_accurate_team("20132014")
+end
 
 # ~~~ TEAM METHOD TESTS~~~
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -154,6 +154,22 @@ class StatTrackerTest < Minitest::Test
     assert_equal 6, @stats.highest_total_score("20142015")
   end
 
+  def test_it_can_get_game_ids_in_season
+    expected = [2013021198, 2013020371, 2013020203, 2013020649, 2013021160, 2013020334, 2013021221, 2013020667, 2013020321, 2013020285, 2013020739, 2013020088]
+    assert_equal expected, @stats.game_ids_per_season("20132014")
+  end
+
+  def test_it_can_get_games_from_season_game_ids
+    season_game_ids = @stats.game_ids_per_season("20132014")
+    assert_equal GameTeam, @stats.find_game_teams(season_game_ids)[0].class
+    assert_equal (season_game_ids.count * 2), @stats.find_game_teams(season_game_ids).count
+  end
+
+  def test_it_can_get_shots_per_team
+    expected = {"4"=>32, "14"=>26, "1"=>27, "6"=>24, "26"=>40}
+    assert_equal expected, @stats.shots_per_team_id("20132014")
+  end
+
 # ~~~ LEAGUE METHOD TESTS~~~
   def test_worst_offense
     assert_equal "Chicago Fire", @stats.worst_offense
@@ -165,6 +181,10 @@ class StatTrackerTest < Minitest::Test
 
 
 # ~~~ SEASON METHOD TESTS~~~
+def test_it_can_find_goals_per_season
+  expected = {"4"=>10, "14"=>9, "1"=>7, "6"=>10, "26"=>11}
+  assert_equal expected, @stats.season_goals("20132014")
+end
 
 
 # ~~~ TEAM METHOD TESTS~~~

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -290,15 +290,15 @@ class StatTrackerTest < Minitest::Test
     assert_equal 30.19, @stats.percentage_away_wins
   end
 
-  def test_it_can_get_percentage_ties
+  def test_it_can_get_percentage_ties ###
     assert_equal 15.09, @stats.percentage_ties
   end
 
-  def test_it_can_get_percentage_home_wins
+  def test_it_can_get_percentage_home_wins ###
     assert_equal 54.72, @stats.percentage_home_wins
   end
 
-  def test_it_can_see_count_of_games_by_season
+  def test_it_can_see_count_of_games_by_season ###
     expected = {"20142015"=>16, "20172018"=>9, "20152016"=>5, "20132014"=>12, "20122013"=>4, "20162017"=>7}
     assert_equal expected, @stats.count_of_games_by_season
   end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -191,6 +191,10 @@ def test_shots_per_goal_per_season_for_given_season
   assert_equal expected, @stats.shots_per_goal_per_season("20132014")
 end
 
+def test_it_can_get_most_accurate_team
+  assert_equal "FC Dallas", @stats.most_accurate_team("20132014")
+end
+
 
 # ~~~ TEAM METHOD TESTS~~~
 end


### PR DESCRIPTION
Add required methods:
- most_accurate_team (takes season_id argument, returns team name as string)
- least_accurate team (takes season_id argument, returns team name as string)

Adds helper methods:
- game_ids_per_season (accepts season_id, gets game ids within given season)
- find_game_teams (finds game_team objects by matching ids given by above method)
- shots_per_team_id (accepts season id, outputs hash w/ team ids as keys and shots made by team in current season as values)
- season_goals (does the same but with goals as keys)
- shots_per_goal_per_season (accepts season id, outputs hash w/ team ids as keys, avg of shots and goals as values)

Also changes require statements in StatTracker to "require_relative" to work with spec